### PR TITLE
feat (user-service): Improve user service navigation flow

### DIFF
--- a/backend/user-service/src/controllers/auth-controllers.js
+++ b/backend/user-service/src/controllers/auth-controllers.js
@@ -74,7 +74,24 @@ exports.verifyUser = async (req, res) => {
     user.verificationCodeExpiry = null;
     await user.save();
 
-    return res.status(200).json({ message: "User verified successfully" });
+    // Log in the user upon successful verification
+    const accessToken = user.generateAccessToken(5 * 60);
+    const refreshToken = user.generateRefreshToken(7 * 24 * 60 * 60);
+    console.log("Access Token:", accessToken);
+    console.log("Refresh Token:", refreshToken);
+
+    // Set HttpOnly cookies
+    res.cookie("refresh_token", refreshToken, {
+      httpOnly: true,
+      path: "/",
+      secure: false,
+      sameSite: "lax",
+      expires: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    });
+
+    return res
+      .status(200)
+      .json({ message: "User verified and logged in successfully", accessToken: accessToken });
   } catch (err) {
     console.error(err);
     return res.status(400).json({ message: "Please try again" });
@@ -204,13 +221,12 @@ exports.refresh = async (req, res) => {
 
 exports.getUserProfile = async (req, res) => {
   try {
-    // const userId = req.params.userid;
     const userId = req.userId; // from auth middleware
     console.log("Fetching profile for userId:", userId);
     if (!userId) {
       return res.status(400).json({ error: "User ID required" });
     }
-    const user = await User.findById(userId); // exclude password
+    const user = await User.findById(userId);
     if (!user) {
       return res.status(404).json({ error: "User not found" });
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     env_file:
       - ./backend/user-service/.env
     environment:
-      MONGO_URI: mongodb://admin:password@mongodb:27017/peerprep?authSource=admin
+      MONGO_URI: mongodb://admin:password@mongodb:27017/peerprepUserDB?authSource=admin
       WEB_BASE_URL: http://localhost:3000
       API_BASE_URL: http://localhost:8001
       PORT: 8001

--- a/frontend/src/app/account/page.tsx
+++ b/frontend/src/app/account/page.tsx
@@ -25,15 +25,20 @@ export default function AccountPage() {
           url: "http://localhost:8001/v1/account",
           withCredentials: true,
         });
-
         setUsername(res.data.username);
         setEmail(res.data.email);
       } catch (err) {
+        let message = "";
+        if (err instanceof Error && err.message === "User is logged out") {
+          message = "Login session expired, please log in again.";
+        } else if (err instanceof Error && err.message === "No access token found") {
+          message = "Please log in to use PeerPrep";
+        }
         console.error("Failed to fetch user:", err);
         setDialog({
           open: true,
-          message: "Login session expired",
-          description: "Please log in again.",
+          message: message,
+          description: "Redirecting to login page in 5 seconds...",
           icon: "circle-x",
           setOpen: () => {},
           showCloseButton: false,

--- a/frontend/src/app/account/page.tsx
+++ b/frontend/src/app/account/page.tsx
@@ -1,71 +1,40 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
 import Navbar from "@/components/ui/nav-bar";
 import MessageDialog from "@/components/ui/message-dialog";
 import AccountForm from "@/components/auth/account-form";
-import { useAuth } from "@/hooks/use-auth";
+import { useAuthContext } from "@/contexts/auth-context";
+import ProtectedRoute from "@/components/auth/protected-route";
 import { DialogState, defaultDialogState } from "@/types/dialog";
 
 export default function AccountPage() {
-  const router = useRouter();
   const [email, setEmail] = useState("");
   const [username, setUsername] = useState("");
   const [dialog, setDialog] = useState<DialogState>(defaultDialogState);
-
-  const { authRequest } = useAuth();
+  const { user } = useAuthContext();
 
   useEffect(() => {
-    let timeout: ReturnType<typeof setTimeout> | null = null;
-    const fetchUser = async () => {
-      try {
-        const res = await authRequest({
-          method: "GET",
-          url: "http://localhost:8001/v1/account",
-          withCredentials: true,
-        });
-        setUsername(res.data.username);
-        setEmail(res.data.email);
-      } catch (err) {
-        let message = "";
-        if (err instanceof Error && err.message === "User is logged out") {
-          message = "Login session expired, please log in again.";
-        } else if (err instanceof Error && err.message === "No access token found") {
-          message = "Please log in to use PeerPrep";
-        }
-        console.error("Failed to fetch user:", err);
-        setDialog({
-          open: true,
-          message: message,
-          description: "Redirecting to login page in 5 seconds...",
-          icon: "circle-x",
-          setOpen: () => {},
-          showCloseButton: false,
-        });
-        timeout = setTimeout(() => {
-          router.push("/auth");
-        }, 5000);
-      }
-    };
-    fetchUser();
-    return () => {
-      if (timeout) clearTimeout(timeout);
-    };
-  }, [authRequest, router]);
+    if (user) {
+      setUsername(user.username);
+      setEmail(user.email);
+    }
+  }, [user]);
 
   return (
-    <div>
-      <Navbar />
-      <AccountForm email={email} originalUsername={username} setDialog={setDialog} />
-      <MessageDialog
-        open={dialog.open}
-        setOpen={dialog.setOpen || ((open: boolean) => setDialog((prev) => ({ ...prev, open })))}
-        title={dialog.message}
-        description={dialog.description}
-        icon={dialog.icon}
-        showCloseButton={dialog.showCloseButton}
-      />
-    </div>
+    <ProtectedRoute>
+      <div>
+        <Navbar />
+        <AccountForm email={email} originalUsername={username} setDialog={setDialog} />
+        <MessageDialog
+          open={dialog.open}
+          setOpen={dialog.setOpen || ((open: boolean) => setDialog((prev) => ({ ...prev, open })))}
+          title={dialog.message}
+          description={dialog.description}
+          icon={dialog.icon}
+          showCloseButton={dialog.showCloseButton}
+        />
+      </div>
+    </ProtectedRoute>
   );
 }

--- a/frontend/src/app/auth/page.tsx
+++ b/frontend/src/app/auth/page.tsx
@@ -6,9 +6,15 @@ import SignUpForm from "@/components/auth/sign-up-form";
 import { useRouter } from "next/navigation";
 import Header from "@/components/ui/header";
 import { Home } from "lucide-react";
+import { useEffect } from "react";
 
 export default function AuthPage() {
   const router = useRouter();
+  useEffect(() => {
+    if (!localStorage.getItem("logout")) {
+      router.push("/matching");
+    }
+  }, [router]);
 
   return (
     <div>

--- a/frontend/src/app/auth/page.tsx
+++ b/frontend/src/app/auth/page.tsx
@@ -4,60 +4,55 @@ import Image from "next/image";
 import SignInForm from "@/components/auth/sign-in-form";
 import SignUpForm from "@/components/auth/sign-up-form";
 import { useRouter } from "next/navigation";
-import Header from "@/components/ui/header";
 import { Home } from "lucide-react";
-import { useEffect } from "react";
+import PublicRoute from "@/components/auth/public-route";
+import Navbar from "@/components/ui/nav-bar";
 
 export default function AuthPage() {
   const router = useRouter();
-  useEffect(() => {
-    if (!localStorage.getItem("logout")) {
-      router.push("/matching");
-    }
-  }, [router]);
 
   return (
-    <div>
-      <Header />
-      <div className="min-h-screen flex items-center justify-center gap-30 p-2 sm:p-4 md:p-8 lg:p-12 xl:p-20">
-        <div className="flex flex-col items-center mb-10 gap-4">
-          <h1 className="scroll-m-20 text-center text-4xl font-extrabold tracking-tight text-balance">
-            Welcome to PeerPrep
-          </h1>
-          <h3 className="scroll-m-20 text-center text-2xl font-semibold tracking-tight text-balance">
-            Collaborate, learn, and prepare for your technical interviews with peers
-          </h3>
-          <Image src="/images/peerprep.png" alt="PeerPrep" width={400} height={400} />
-        </div>
-        <div className="w-full max-w-sm flex-col gap-6 flex">
-          <Tabs defaultValue="sign-in">
-            <TabsList className="grid w-full grid-cols-3 items-center text-center">
-              <div className="flex justify-center">
-                <Home
-                  className="text-muted-foreground hover:cursor-pointer text-2xl"
-                  onClick={() => router.push("/")}
-                />
-              </div>
-              <div className="flex justify-center">
-                <TabsTrigger value="sign-in">Sign In</TabsTrigger>
-              </div>
-              <div className="flex justify-center">
-                <TabsTrigger value="sign-up">Sign Up</TabsTrigger>
-              </div>
-            </TabsList>
+    <PublicRoute>
+      <div>
+        <Navbar />
+        <div className="min-h-screen flex items-center justify-center gap-30 p-2 sm:p-4 md:p-8 lg:p-12 xl:p-20">
+          <div className="flex flex-col items-center mb-10 gap-4">
+            <h1 className="scroll-m-20 text-center text-4xl font-extrabold tracking-tight text-balance">
+              Welcome to PeerPrep
+            </h1>
+            <h3 className="scroll-m-20 text-center text-2xl font-semibold tracking-tight text-balance">
+              Collaborate, learn, and prepare for your technical interviews with peers
+            </h3>
+            <Image src="/images/peerprep.png" alt="PeerPrep" width={400} height={400} />
+          </div>
+          <div className="w-full max-w-sm flex-col gap-6 flex">
+            <Tabs defaultValue="sign-in">
+              <TabsList className="grid w-full grid-cols-3 items-center text-center">
+                <div className="flex justify-center">
+                  <Home
+                    className="text-muted-foreground hover:cursor-pointer text-2xl"
+                    onClick={() => router.push("/")}
+                  />
+                </div>
+                <div className="flex justify-center">
+                  <TabsTrigger value="sign-in">Sign In</TabsTrigger>
+                </div>
+                <div className="flex justify-center">
+                  <TabsTrigger value="sign-up">Sign Up</TabsTrigger>
+                </div>
+              </TabsList>
 
-            {/* Sign In */}
-            <TabsContent value="sign-in">
-              <SignInForm />
-            </TabsContent>
+              <TabsContent value="sign-in">
+                <SignInForm />
+              </TabsContent>
 
-            {/* Sign Up */}
-            <TabsContent value="sign-up">
-              <SignUpForm />
-            </TabsContent>
-          </Tabs>
+              <TabsContent value="sign-up">
+                <SignUpForm />
+              </TabsContent>
+            </Tabs>
+          </div>
         </div>
       </div>
-    </div>
+    </PublicRoute>
   );
 }

--- a/frontend/src/app/forgot-pw/[token]/page.tsx
+++ b/frontend/src/app/forgot-pw/[token]/page.tsx
@@ -1,15 +1,18 @@
 "use client";
 import Header from "@/components/ui/header";
 import ResetPasswordForm from "@/components/auth/reset-password-form";
+import PublicRoute from "@/components/auth/public-route";
 
 export default function ResetPasswordPage() {
   return (
-    <div>
-      <Header />
-      <h1 className="mt-40 text-center text-3xl sm:text-4xl font-extrabold tracking-tight">
-        Reset Password
-      </h1>
-      <ResetPasswordForm />
-    </div>
+    <PublicRoute>
+      <div>
+        <Header />
+        <h1 className="mt-40 text-center text-3xl sm:text-4xl font-extrabold tracking-tight">
+          Reset Password
+        </h1>
+        <ResetPasswordForm />
+      </div>
+    </PublicRoute>
   );
 }

--- a/frontend/src/app/forgot-pw/page.tsx
+++ b/frontend/src/app/forgot-pw/page.tsx
@@ -8,6 +8,7 @@ import MessageDialog from "@/components/ui/message-dialog";
 import { useMutation } from "@tanstack/react-query";
 import axios, { AxiosError } from "axios";
 import { Spinner } from "@/components/ui/spinner";
+import PublicRoute from "@/components/auth/public-route";
 
 type ForgotPasswordPayload = {
   email: string;
@@ -69,42 +70,44 @@ export default function ForgotPasswordPage() {
   const isLoading = mutation.isPending;
 
   return (
-    <div>
-      <Header />
-      <h1 className="mt-40 text-center text-3xl sm:text-4xl font-extrabold tracking-tight">
-        Forgot your password?
-      </h1>
-      <div className="mt-20 flex items-center justify-center ">
-        <div className="w-full max-w-md rounded-2xl bg-white shadow-lg sm:p-8 space-y-6">
-          <p className="text-center text-sm sm:text-base font-medium text-gray-600">
-            Enter your email to receive a password reset link.
-          </p>
-          <div className="space-y-4">
-            <form onSubmit={handleSendEmail}>
-              <Input
-                type="email"
-                placeholder="Email"
-                onChange={(e) => setEmail(e.target.value)}
-                required
-              />
-              <Button className="mt-4 w-full" type="submit">
-                {isLoading ? <Spinner /> : "Send Email"}
+    <PublicRoute>
+      <div>
+        <Header />
+        <h1 className="mt-40 text-center text-3xl sm:text-4xl font-extrabold tracking-tight">
+          Forgot your password?
+        </h1>
+        <div className="mt-20 flex items-center justify-center ">
+          <div className="w-full max-w-md rounded-2xl bg-white shadow-lg sm:p-8 space-y-6">
+            <p className="text-center text-sm sm:text-base font-medium text-gray-600">
+              Enter your email to receive a password reset link.
+            </p>
+            <div className="space-y-4">
+              <form onSubmit={handleSendEmail}>
+                <Input
+                  type="email"
+                  placeholder="Email"
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                />
+                <Button className="mt-4 w-full" type="submit">
+                  {isLoading ? <Spinner /> : "Send Email"}
+                </Button>
+              </form>
+              <Button variant="outline" className="w-full" onClick={handleBackToLogin}>
+                Back to login
               </Button>
-            </form>
-            <Button variant="outline" className="w-full" onClick={handleBackToLogin}>
-              Back to login
-            </Button>
+            </div>
           </div>
         </div>
-      </div>
 
-      <MessageDialog
-        open={open}
-        setOpen={setOpen}
-        title={title}
-        description={description}
-        icon={icon}
-      />
-    </div>
+        <MessageDialog
+          open={open}
+          setOpen={setOpen}
+          title={title}
+          description={description}
+          icon={icon}
+        />
+      </div>
+    </PublicRoute>
   );
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ReactNode } from "react";
 import { ReactQueryProvider } from "@/components/provider/react-query-provider";
+import { AuthProvider } from "@/contexts/auth-context";
 import { TimerOverlay } from "@/components/matching/timer-overlay";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
@@ -30,7 +31,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <ReactQueryProvider>{children}</ReactQueryProvider>
+        <ReactQueryProvider>
+          <AuthProvider>{children}</AuthProvider>
+        </ReactQueryProvider>
         <TimerOverlay />
         <ToastContainer />
       </body>

--- a/frontend/src/app/matching/page.tsx
+++ b/frontend/src/app/matching/page.tsx
@@ -10,8 +10,14 @@ import ProtectedRoute from "@/components/auth/protected-route";
 
 export default function MatchingPage() {
   const router = useRouter();
-  const { user } = useAuthContext();
+  const { user, isUser } = useAuthContext();
   const { roomId, matchFound, initializeSocket, setUser, cleanup } = useMatchingStore();
+
+  useEffect(() => {
+    if (!isUser) {
+      router.push("/");
+    }
+  }, [isUser, router]);
 
   useEffect(() => {
     if (matchFound && roomId) {

--- a/frontend/src/app/matching/page.tsx
+++ b/frontend/src/app/matching/page.tsx
@@ -39,9 +39,15 @@ export default function MatchingPage() {
         }
       } catch (err) {
         console.error("Failed to fetch user:", err);
+        let message = "";
+        if (err instanceof Error && err.message === "User is logged out") {
+          message = "Login session expired, please log in again.";
+        } else if (err instanceof Error && err.message === "No access token found") {
+          message = "Please log in to use PeerPrep";
+        }
         setDialog({
           open: true,
-          message: "Login session expired, please log in again.",
+          message: message,
           description: "Redirecting to login page in 5 seconds...",
           icon: "circle-x",
           setOpen: () => {},

--- a/frontend/src/app/matching/page.tsx
+++ b/frontend/src/app/matching/page.tsx
@@ -1,19 +1,17 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import MatchMake from "@/components/matching/match-make";
 import { useMatchingStore } from "@/stores/matching-store";
-import { useAuth } from "@/hooks/use-auth";
+import { useAuthContext } from "@/contexts/auth-context";
 import Navbar from "@/components/ui/nav-bar";
-import MessageDialog from "@/components/ui/message-dialog";
-import { DialogState, defaultDialogState } from "@/types/dialog";
+import ProtectedRoute from "@/components/auth/protected-route";
 
 export default function MatchingPage() {
   const router = useRouter();
-  const { authRequest } = useAuth();
+  const { user } = useAuthContext();
   const { roomId, matchFound, initializeSocket, setUser, cleanup } = useMatchingStore();
-  const [dialog, setDialog] = useState<DialogState>(defaultDialogState);
 
   useEffect(() => {
     if (matchFound && roomId) {
@@ -22,47 +20,11 @@ export default function MatchingPage() {
   }, [matchFound, roomId, router]);
 
   useEffect(() => {
-    let timeout: ReturnType<typeof setTimeout> | null = null;
-    const fetchUser = async () => {
-      try {
-        const res = await authRequest({
-          method: "GET",
-          url: "http://localhost:8001/v1/account",
-          withCredentials: true,
-        });
-        const authUser = res.data;
-        setUser(authUser);
-        initializeSocket(authUser);
-        if (timeout) {
-          clearTimeout(timeout);
-          timeout = null;
-        }
-      } catch (err) {
-        console.error("Failed to fetch user:", err);
-        let message = "";
-        if (err instanceof Error && err.message === "User is logged out") {
-          message = "Login session expired, please log in again.";
-        } else if (err instanceof Error && err.message === "No access token found") {
-          message = "Please log in to use PeerPrep";
-        }
-        setDialog({
-          open: true,
-          message: message,
-          description: "Redirecting to login page in 5 seconds...",
-          icon: "circle-x",
-          setOpen: () => {},
-          showCloseButton: false,
-        });
-        timeout = setTimeout(() => {
-          router.push("/auth");
-        }, 5000);
-      }
-    };
-    fetchUser();
-    return () => {
-      if (timeout) clearTimeout(timeout);
-    };
-  }, [authRequest, initializeSocket, setUser, router]);
+    if (user) {
+      setUser(user);
+      initializeSocket(user);
+    }
+  }, [user, setUser, initializeSocket]);
 
   // Cleanup socket when component unmounts
   useEffect(() => {
@@ -76,19 +38,13 @@ export default function MatchingPage() {
   }, [cleanup]);
 
   return (
-    <div className="min-h-screen bg-[#d4eaf8]">
-      <Navbar />
-      <main className="pt-8">
-        <MatchMake />
-      </main>
-      <MessageDialog
-        open={dialog.open}
-        setOpen={dialog.setOpen || ((open: boolean) => setDialog((prev) => ({ ...prev, open })))}
-        title={dialog.message}
-        description={dialog.description}
-        icon={dialog.icon}
-        showCloseButton={dialog.showCloseButton}
-      />
-    </div>
+    <ProtectedRoute>
+      <div className="min-h-screen bg-[#d4eaf8]">
+        <Navbar />
+        <main className="pt-8">
+          <MatchMake />
+        </main>
+      </div>
+    </ProtectedRoute>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,8 +1,17 @@
+"use client";
 import Header from "@/components/ui/header";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 
 export default function LandingPage() {
+  const router = useRouter();
+  useEffect(() => {
+    if (!localStorage.getItem("logout")) {
+      router.push("/matching");
+    }
+  }, [router]);
   return (
     <main>
       <Header />

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,20 +1,15 @@
 "use client";
-import Header from "@/components/ui/header";
+import Navbar from "@/components/ui/nav-bar";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useAuthContext } from "@/contexts/auth-context";
 
 export default function LandingPage() {
-  const router = useRouter();
-  useEffect(() => {
-    if (!localStorage.getItem("logout")) {
-      router.push("/matching");
-    }
-  }, [router]);
+  const { isAuthenticated } = useAuthContext();
+
   return (
     <main>
-      <Header />
+      <Navbar />
       <section className="bg-background min-h-screen flex flex-col items-center justify-center text-center p-6">
         <h1 className="text-4xl sm:text-5xl font-extrabold mb-4">Welcome to PeerPrep</h1>
         <p className="text-lg sm:text-xl text-gray-700 mb-6 max-w-2xl">
@@ -22,9 +17,15 @@ export default function LandingPage() {
           prepare confidently for your next job. Solve challenges, track progress, and collaborate
           with peers to level up your interview game.
         </p>
-        <Link href="/auth">
-          <Button className="w-full">Get Started</Button>
-        </Link>
+        {isAuthenticated ? (
+          <Link href="/matching">
+            <Button className="w-full">Go to Matching</Button>
+          </Link>
+        ) : (
+          <Link href="/auth">
+            <Button className="w-full">Get Started</Button>
+          </Link>
+        )}
       </section>
     </main>
   );

--- a/frontend/src/app/verify/[token]/page.tsx
+++ b/frontend/src/app/verify/[token]/page.tsx
@@ -30,6 +30,7 @@ type VerifyPayload = {
 
 type VerifyResponse = {
   message?: string;
+  accessToken?: string;
 };
 
 type BackendError = {
@@ -54,8 +55,20 @@ export default function VerifyAccountPage() {
     onSuccess: (data) => {
       setOpen(true);
       setTitle("Verify account successfully!");
-      setDescription(data.message || "You may now log in to your account.");
-      setIcon("user-round-check");
+      console.log(data.message);
+      if (data.accessToken) {
+        localStorage.setItem("accessToken", data.accessToken);
+        localStorage.removeItem("logout");
+        setDescription("Redirecting to matching page in 5 seconds...");
+        setIcon("user-round-check");
+        setTimeout(() => {
+          router.push("/matching");
+        }, 5000);
+      } else {
+        console.log("No access token received upon verification.");
+        setDescription("You can now log in to your account.");
+        setIcon("circle-check");
+      }
     },
     onError: (error) => {
       setOpen(true);

--- a/frontend/src/app/verify/[token]/page.tsx
+++ b/frontend/src/app/verify/[token]/page.tsx
@@ -190,15 +190,6 @@ export default function VerifyAccountPage() {
                   {isResendLoading ? <Spinner /> : "Resend code"}
                 </Button>
               </CardFooter>
-              <Button
-                type="button"
-                variant="link"
-                size="sm"
-                onClick={() => router.push("/auth")}
-                className="w-full"
-              >
-                Back to login
-              </Button>
             </Card>
           </form>
         </div>

--- a/frontend/src/app/verify/[token]/page.tsx
+++ b/frontend/src/app/verify/[token]/page.tsx
@@ -22,6 +22,8 @@ import axios, { AxiosError } from "axios";
 import MessageDialog from "@/components/ui/message-dialog";
 import { useRouter } from "next/navigation";
 import { Spinner } from "@/components/ui/spinner";
+import PublicRoute from "@/components/auth/public-route";
+import { useAuthContext } from "@/contexts/auth-context";
 
 type VerifyPayload = {
   verificationCode: number;
@@ -46,19 +48,20 @@ export default function VerifyAccountPage() {
   const [description, setDescription] = useState("");
   const [icon, setIcon] = useState("");
   const router = useRouter();
+  const { checkAuth } = useAuthContext();
 
   const mutation = useMutation<VerifyResponse, AxiosError<BackendError>, VerifyPayload>({
     mutationFn: async (payload) => {
       const res = await axios.post<VerifyResponse>("http://localhost:8001/v1/verify", payload);
       return res.data;
     },
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       setOpen(true);
       setTitle("Verify account successfully!");
       console.log(data.message);
       if (data.accessToken) {
         localStorage.setItem("accessToken", data.accessToken);
-        localStorage.removeItem("logout");
+        await checkAuth(); // Update auth context
         setDescription("Redirecting to matching page in 5 seconds...");
         setIcon("user-round-check");
         setTimeout(() => {
@@ -128,84 +131,86 @@ export default function VerifyAccountPage() {
   const isResendLoading = resendMutation.isPending;
 
   return (
-    <div>
-      <Header />
-      <div className="min-h-screen flex flex-col items-center justify-center gap-10">
-        <div className="flex flex-col items-center gap-4 text-center">
-          <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight text-balance">
-            Account Verification
-          </h1>
-        </div>
+    <PublicRoute>
+      <div>
+        <Header />
+        <div className="min-h-screen flex flex-col items-center justify-center gap-10">
+          <div className="flex flex-col items-center gap-4 text-center">
+            <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight text-balance">
+              Account Verification
+            </h1>
+          </div>
 
-        <form onSubmit={handleSubmit} className="w-full max-w-sm">
-          <Card>
-            <CardHeader className="items-center text-center">
-              <CardTitle>We have sent a verification code to your email address.</CardTitle>
-              <CardDescription>Enter the code below to verify your account</CardDescription>
-            </CardHeader>
+          <form onSubmit={handleSubmit} className="w-full max-w-sm">
+            <Card>
+              <CardHeader className="items-center text-center">
+                <CardTitle>We have sent a verification code to your email address.</CardTitle>
+                <CardDescription>Enter the code below to verify your account</CardDescription>
+              </CardHeader>
 
-            <CardContent className="grid gap-6">
-              <div className="grid gap-3">
-                <InputOTP
-                  maxLength={6}
-                  onChange={(value: string) => {
-                    const numericValue = value.replace(/\D/g, "");
-                    setOtp(numericValue);
-                  }}
+              <CardContent className="grid gap-6">
+                <div className="grid gap-3">
+                  <InputOTP
+                    maxLength={6}
+                    onChange={(value: string) => {
+                      const numericValue = value.replace(/\D/g, "");
+                      setOtp(numericValue);
+                    }}
+                  >
+                    <InputOTPGroup>
+                      <InputOTPSlot index={0} />
+                      <InputOTPSlot index={1} />
+                      <InputOTPSlot index={2} />
+                    </InputOTPGroup>
+                    <InputOTPSeparator />
+                    <InputOTPGroup>
+                      <InputOTPSlot index={3} />
+                      <InputOTPSlot index={4} />
+                      <InputOTPSlot index={5} />
+                    </InputOTPGroup>
+                  </InputOTP>
+                  {error && <p className="text-red-600 text-sm">{error}</p>}
+                </div>
+              </CardContent>
+
+              <CardFooter>
+                <Button type="submit" className="w-full" disabled={isVerifyLoading}>
+                  {isVerifyLoading ? <Spinner /> : "Verify"}
+                </Button>
+              </CardFooter>
+              <CardFooter>
+                <Button
+                  type="button"
+                  variant="default"
+                  size="sm"
+                  onClick={handleResendCode}
+                  className="w-full"
+                  disabled={isResendLoading}
                 >
-                  <InputOTPGroup>
-                    <InputOTPSlot index={0} />
-                    <InputOTPSlot index={1} />
-                    <InputOTPSlot index={2} />
-                  </InputOTPGroup>
-                  <InputOTPSeparator />
-                  <InputOTPGroup>
-                    <InputOTPSlot index={3} />
-                    <InputOTPSlot index={4} />
-                    <InputOTPSlot index={5} />
-                  </InputOTPGroup>
-                </InputOTP>
-                {error && <p className="text-red-600 text-sm">{error}</p>}
-              </div>
-            </CardContent>
-
-            <CardFooter>
-              <Button type="submit" className="w-full" disabled={isVerifyLoading}>
-                {isVerifyLoading ? <Spinner /> : "Verify"}
-              </Button>
-            </CardFooter>
-            <CardFooter>
+                  {isResendLoading ? <Spinner /> : "Resend code"}
+                </Button>
+              </CardFooter>
               <Button
                 type="button"
-                variant="default"
+                variant="link"
                 size="sm"
-                onClick={handleResendCode}
+                onClick={() => router.push("/auth")}
                 className="w-full"
-                disabled={isResendLoading}
               >
-                {isResendLoading ? <Spinner /> : "Resend code"}
+                Back to login
               </Button>
-            </CardFooter>
-            <Button
-              type="button"
-              variant="link"
-              size="sm"
-              onClick={() => router.push("/auth")}
-              className="w-full"
-            >
-              Back to login
-            </Button>
-          </Card>
-        </form>
-      </div>
+            </Card>
+          </form>
+        </div>
 
-      <MessageDialog
-        open={open}
-        setOpen={setOpen}
-        title={title}
-        description={description}
-        icon={icon}
-      />
-    </div>
+        <MessageDialog
+          open={open}
+          setOpen={setOpen}
+          title={title}
+          description={description}
+          icon={icon}
+        />
+      </div>
+    </PublicRoute>
   );
 }

--- a/frontend/src/components/auth/account-form.tsx
+++ b/frontend/src/components/auth/account-form.tsx
@@ -84,7 +84,7 @@ export default function AccountForm({ email, originalUsername, setDialog }: Acco
             />
             <button
               type="button"
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 z-10"
               disabled={!editMode}
               onClick={() => setShowPassword((prev) => ({ ...prev, current: !prev.current }))}
             >
@@ -109,7 +109,7 @@ export default function AccountForm({ email, originalUsername, setDialog }: Acco
             />
             <button
               type="button"
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 z-10"
               disabled={!editMode}
               onClick={() => setShowPassword((prev) => ({ ...prev, new: !prev.new }))}
             >
@@ -135,7 +135,7 @@ export default function AccountForm({ email, originalUsername, setDialog }: Acco
             />
             <button
               type="button"
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 z-10"
               disabled={!editMode}
               onClick={() => setShowPassword((prev) => ({ ...prev, confirm: !prev.confirm }))}
             >

--- a/frontend/src/components/auth/logout-button.tsx
+++ b/frontend/src/components/auth/logout-button.tsx
@@ -18,11 +18,9 @@ export default function LogoutButton() {
       });
 
       console.log("Logout successful:", res.data);
-
-      // Optionally remove token if using JWT
       localStorage.removeItem("accessToken");
+      localStorage.setItem("logout", Date.now().toString());
 
-      // Redirect to login
       router.push("/");
     } catch (err: unknown) {
       const error = err as AxiosError;

--- a/frontend/src/components/auth/logout-button.tsx
+++ b/frontend/src/components/auth/logout-button.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { AxiosError } from "axios";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/use-auth";
+import { useAuthContext } from "@/contexts/auth-context";
 
 export default function LogoutButton() {
-  const router = useRouter();
   const { authRequest } = useAuth();
+  const { logout } = useAuthContext();
 
   const handleLogout = async () => {
     try {
@@ -18,13 +18,11 @@ export default function LogoutButton() {
       });
 
       console.log("Logout successful:", res.data);
-      localStorage.removeItem("accessToken");
-      localStorage.setItem("logout", Date.now().toString());
-
-      router.push("/");
+      logout();
     } catch (err: unknown) {
       const error = err as AxiosError;
       console.error("Logout failed:", error.response?.data || error.message);
+      logout();
     }
   };
 

--- a/frontend/src/components/auth/protected-route.tsx
+++ b/frontend/src/components/auth/protected-route.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { ReactNode, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuthContext } from "@/contexts/auth-context";
+import MessageDialog from "@/components/ui/message-dialog";
+import { DialogState, defaultDialogState } from "@/types/dialog";
+import { Spinner } from "@/components/ui/spinner";
+
+interface ProtectedRouteProps {
+  children: ReactNode;
+}
+
+export default function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const { isAuthenticated, isLoading } = useAuthContext();
+  const router = useRouter();
+  const [dialog, setDialog] = useState<DialogState>(defaultDialogState);
+  const [showExpiredDialog, setShowExpiredDialog] = useState(false);
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      // Check if this is due to token expiration (not just no token)
+      const accessToken = localStorage.getItem("accessToken");
+
+      if (accessToken) {
+        // Token exists but auth failed - likely expired
+        setShowExpiredDialog(true);
+        setDialog({
+          open: true,
+          message: "Session expired",
+          description: "Your login session has expired. Please log in again.",
+          icon: "circle-x",
+          setOpen: () => {},
+          showCloseButton: false,
+        });
+
+        setTimeout(() => {
+          router.push("/auth");
+        }, 3000);
+      } else {
+        // No token - redirect immediately
+        router.push("/auth");
+      }
+    }
+  }, [isAuthenticated, isLoading, router]);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <>
+        {showExpiredDialog && (
+          <MessageDialog
+            open={dialog.open}
+            setOpen={
+              dialog.setOpen || ((open: boolean) => setDialog((prev) => ({ ...prev, open })))
+            }
+            title={dialog.message}
+            description={dialog.description}
+            icon={dialog.icon}
+            showCloseButton={dialog.showCloseButton}
+          />
+        )}
+        <div className="min-h-screen flex items-center justify-center">
+          <Spinner />
+        </div>
+      </>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/auth/public-route.tsx
+++ b/frontend/src/components/auth/public-route.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { ReactNode, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuthContext } from "@/contexts/auth-context";
+import { Spinner } from "@/components/ui/spinner";
+
+interface PublicRouteProps {
+  children: ReactNode;
+  redirectTo?: string;
+}
+
+export default function PublicRoute({ children, redirectTo = "/matching" }: PublicRouteProps) {
+  const { isAuthenticated, isLoading } = useAuthContext();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) {
+      router.push(redirectTo);
+    }
+  }, [isAuthenticated, isLoading, router, redirectTo]);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isAuthenticated) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/auth/reset-password-form.tsx
+++ b/frontend/src/components/auth/reset-password-form.tsx
@@ -72,8 +72,11 @@ export default function ResetPasswordForm() {
     onSuccess: () => {
       setOpen(true);
       setMessage("Password reset successful");
-      setDescription("You may now log in with your new password");
+      setDescription("Redirecting to login page in 5 seconds...");
       setIcon("circle-check");
+      setTimeout(() => {
+        router.push("/auth");
+      }, 5000);
     },
     onError: (error) => {
       const backendMsg = error.response?.data?.error || error.message;

--- a/frontend/src/components/auth/reset-password-form.tsx
+++ b/frontend/src/components/auth/reset-password-form.tsx
@@ -126,7 +126,7 @@ export default function ResetPasswordForm() {
                 />
                 <button
                   type="button"
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 z-10"
                   onClick={() => setShowPassword((s) => !s)}
                 >
                   {showPassword ? <Eye size={20} /> : <EyeOff size={20} />}
@@ -152,7 +152,7 @@ export default function ResetPasswordForm() {
                 />
                 <button
                   type="button"
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 z-10"
                   onClick={() => setShowRetypePassword((s) => !s)}
                 >
                   {showRetypePassword ? <Eye size={20} /> : <EyeOff size={20} />}

--- a/frontend/src/components/auth/sign-in-form.tsx
+++ b/frontend/src/components/auth/sign-in-form.tsx
@@ -21,6 +21,7 @@ import MessageDialog from "../ui/message-dialog";
 import { Spinner } from "@/components/ui/spinner";
 import { useRouter } from "next/navigation";
 import { DialogState, defaultDialogState } from "@/types/dialog";
+import { useAuthContext } from "@/contexts/auth-context";
 
 type FormValues = {
   username: string;
@@ -44,6 +45,7 @@ type BackendError = {
 
 export default function SignInForm() {
   const router = useRouter();
+  const { checkAuth } = useAuthContext();
 
   const {
     register,
@@ -67,9 +69,9 @@ export default function SignInForm() {
       });
       return res.data;
     },
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       localStorage.setItem("accessToken", data.accessToken);
-      localStorage.removeItem("logout");
+      await checkAuth(); // Update auth context
       setDialog({
         open: true,
         message: "Login successful",
@@ -140,7 +142,7 @@ export default function SignInForm() {
                 />
                 <button
                   type="button"
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 z-10"
                   onClick={() => setShowPassword((s) => !s)}
                 >
                   {showPassword ? <Eye size={20} /> : <EyeOff size={20} />}

--- a/frontend/src/components/auth/sign-in-form.tsx
+++ b/frontend/src/components/auth/sign-in-form.tsx
@@ -69,6 +69,7 @@ export default function SignInForm() {
     },
     onSuccess: (data) => {
       localStorage.setItem("accessToken", data.accessToken);
+      localStorage.removeItem("logout");
       setDialog({
         open: true,
         message: "Login successful",

--- a/frontend/src/components/auth/sign-up-form.tsx
+++ b/frontend/src/components/auth/sign-up-form.tsx
@@ -64,8 +64,8 @@ export default function SignUpForm() {
 
   const [showPassword, setShowPassword] = useState(false);
   const [showRetypePassword, setShowRetypePassword] = useState(false);
+  const [isRedirecting, setIsRedirecting] = useState(false);
 
-  // mutation
   const mutation = useMutation<RegisterResponse, AxiosError<BackendError>, RegisterRequest>({
     mutationFn: async (newUser) => {
       const res = await axios.post("http://localhost:8001/v1/register", newUser);
@@ -75,10 +75,24 @@ export default function SignUpForm() {
       reset();
       const verificationToken = data.verificationToken;
       if (verificationToken) {
-        router.push(`/verify/${verificationToken}`);
+        setIsRedirecting(true);
+        setDialog({
+          open: true,
+          message: "Registration successful!",
+          description:
+            "Please check your email for the verification code. Redirecting to verification page...",
+          icon: "circle-check",
+          setOpen: () => {},
+          showCloseButton: false,
+        });
+
+        setTimeout(() => {
+          router.push(`/verify/${verificationToken}`);
+        }, 1500);
       }
     },
     onError: (error) => {
+      setIsRedirecting(false);
       const backendMessage = error.response?.data?.error;
       setDialog({
         open: true,
@@ -181,7 +195,7 @@ export default function SignUpForm() {
                 />
                 <button
                   type="button"
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 z-10"
                   onClick={() => setShowPassword((s) => !s)}
                 >
                   {showPassword ? <Eye size={20} /> : <EyeOff size={20} />}
@@ -207,7 +221,7 @@ export default function SignUpForm() {
                 />
                 <button
                   type="button"
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 z-10"
                   onClick={() => setShowRetypePassword((s) => !s)}
                 >
                   {showRetypePassword ? <Eye size={20} /> : <EyeOff size={20} />}
@@ -220,8 +234,20 @@ export default function SignUpForm() {
           </CardContent>
 
           <CardFooter>
-            <Button type="submit" disabled={isLoading}>
-              {isLoading ? <Spinner /> : "Sign up"}
+            <Button type="submit" disabled={isLoading || isRedirecting}>
+              {isLoading ? (
+                <>
+                  <Spinner />
+                  <span className="ml-2">Creating account...</span>
+                </>
+              ) : isRedirecting ? (
+                <>
+                  <Spinner />
+                  <span className="ml-2">Redirecting...</span>
+                </>
+              ) : (
+                "Sign up"
+              )}
             </Button>
           </CardFooter>
         </Card>

--- a/frontend/src/components/ui/nav-bar.tsx
+++ b/frontend/src/components/ui/nav-bar.tsx
@@ -8,38 +8,43 @@ import {
 } from "@/components/ui/navigation-menu";
 import Link from "next/link";
 import LogoutButton from "../auth/logout-button";
+import { useAuthContext } from "@/contexts/auth-context";
 
 export default function Navbar() {
+  const { isAuthenticated } = useAuthContext();
+
   return (
-    <div className="w-full bg-[#20222E] text-white flex items-center justify-between px-4 py-2">
+    <div className="w-full h-16 bg-[#20222E] text-white flex items-center justify-between px-4 py-2">
       <h1 className="text-xl font-bold">PeerPrep</h1>
-      <nav className="px-4 py-2">
-        <NavigationMenu>
-          <NavigationMenuList className="flex gap-4">
-            <NavigationMenuItem>
-              <NavigationMenuLink asChild>
-                <Link href="/">Home</Link>
-              </NavigationMenuLink>
-            </NavigationMenuItem>
+      {isAuthenticated && (
+        <nav className="px-4 py-2">
+          <NavigationMenu>
+            <NavigationMenuList className="flex gap-4">
+              <NavigationMenuItem>
+                <NavigationMenuLink asChild>
+                  <Link href="/">Home</Link>
+                </NavigationMenuLink>
+              </NavigationMenuItem>
 
-            <NavigationMenuItem>
-              <NavigationMenuLink asChild>
-                <Link href="/matching">Practice</Link>
-              </NavigationMenuLink>
-            </NavigationMenuItem>
+              <NavigationMenuItem>
+                <NavigationMenuLink asChild>
+                  <Link href="/matching">Practice</Link>
+                </NavigationMenuLink>
+              </NavigationMenuItem>
 
-            <NavigationMenuItem>
-              <NavigationMenuLink asChild>
-                <Link href="/account">Account</Link>
-              </NavigationMenuLink>
-            </NavigationMenuItem>
+              <NavigationMenuItem>
+                <NavigationMenuLink asChild>
+                  <Link href="/account">Account</Link>
+                </NavigationMenuLink>
+              </NavigationMenuItem>
 
-            <NavigationMenuItem>
-              <LogoutButton />
-            </NavigationMenuItem>
-          </NavigationMenuList>
-        </NavigationMenu>
-      </nav>
+              <NavigationMenuItem>
+                <LogoutButton />
+              </NavigationMenuItem>
+            </NavigationMenuList>
+          </NavigationMenu>
+        </nav>
+      )}
     </div>
   );
 }

--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  ReactNode,
+  useCallback,
+} from "react";
+import { useAuth } from "@/hooks/use-auth";
+import { useRouter } from "next/navigation";
+
+interface User {
+  _id: string;
+  username: string;
+  email: string;
+}
+
+interface AuthContextType {
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  user: User | null;
+  checkAuth: () => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function useAuthContext() {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error("useAuthContext must be used within an AuthProvider");
+  }
+  return context;
+}
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+export function AuthProvider({ children }: AuthProviderProps) {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [user, setUser] = useState<User | null>(null);
+  const { authRequest } = useAuth();
+  const router = useRouter();
+
+  const checkAuth = useCallback(async () => {
+    try {
+      setIsLoading(true);
+
+      // Check if access token exists
+      const accessToken = localStorage.getItem("accessToken");
+      if (!accessToken) {
+        setIsAuthenticated(false);
+        setUser(null);
+        return;
+      }
+
+      const res = await authRequest({
+        method: "GET",
+        url: "http://localhost:8001/v1/account",
+        withCredentials: true,
+      });
+
+      const userData = res.data;
+      setUser(userData);
+      setIsAuthenticated(true);
+    } catch (err) {
+      console.log("Authentication failed, clearing session", err);
+      setIsAuthenticated(false);
+      setUser(null);
+
+      localStorage.removeItem("accessToken");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [authRequest]);
+
+  const logout = () => {
+    localStorage.removeItem("accessToken");
+    setIsAuthenticated(false);
+    setUser(null);
+    router.push("/");
+  };
+
+  useEffect(() => {
+    checkAuth();
+  }, [checkAuth]);
+
+  const value: AuthContextType = {
+    isAuthenticated,
+    isLoading,
+    user,
+    checkAuth,
+    logout,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -15,12 +15,15 @@ interface User {
   _id: string;
   username: string;
   email: string;
+  role: "user" | "admin";
 }
 
 interface AuthContextType {
   isAuthenticated: boolean;
   isLoading: boolean;
   user: User | null;
+  isAdmin: boolean;
+  isUser: boolean;
   checkAuth: () => Promise<void>;
   logout: () => void;
 }
@@ -93,6 +96,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
     isAuthenticated,
     isLoading,
     user,
+    isAdmin: user?.role === "admin",
+    isUser: user?.role === "user",
     checkAuth,
     logout,
   };

--- a/frontend/src/hooks/use-account-form.ts
+++ b/frontend/src/hooks/use-account-form.ts
@@ -109,7 +109,7 @@ export function useAccountForm({ email, originalUsername, setDialog }: UseAccoun
     onSuccess: (data) => {
       setDialog({
         open: true,
-        message: "Updated user profile successfully",
+        message: "Update user profile successfully",
         description: data.message,
         icon: "user-round-check",
       });

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -21,10 +21,11 @@ export function useAuth() {
         err.response?.status === 401 &&
         err.response?.data?.error === "Invalid or expired refresh token"
       ) {
-        console.error("Refresh token has expired:", err);
+        console.log("Refresh token has expired, user needs to log in again");
         localStorage.removeItem("accessToken");
+      } else {
+        console.error("Failed to refresh access token:", err);
       }
-      console.error("Failed to refresh access token:", err);
       return null;
     }
   }, []);

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -33,6 +33,10 @@ export function useAuth() {
   const authRequest = useCallback(
     async (config: AxiosRequestConfig) => {
       config.withCredentials = true;
+      const isLoggedOut = localStorage.getItem("logout");
+      if (isLoggedOut) {
+        throw new Error("User is logged out");
+      }
       const accessToken = localStorage.getItem("accessToken");
       if (!accessToken) throw new Error("No access token found");
 


### PR DESCRIPTION
This PR improves the user service navigation flow:
- Automatically log in users after successfully verifying their account.
- Prevent logged-in users from accessing public pages (including landing and authentication pages); attempts are redirected to `/matching`
- Prevent new users (who have never logged in) and logged-out users from accessing protected pages. attempts are redirected to `/auth`
- After a successful password reset, automatically redirect users to the login page `/auth`.
- Update database configuration to use `peerprepUserDB`, ensuring each service uses its own database.