### PR TITLE
feat (backend): Implement Question Service 

### DIFF
--- a/.github/workflows/ci-question-service.yml
+++ b/.github/workflows/ci-question-service.yml
@@ -1,0 +1,64 @@
+name: CI (backend - question service)
+
+on:
+  pull_request:
+    branches: [dev, staging]
+    paths:
+      - "backend/question-service/**"
+      - "pnpm-lock.yaml"
+      - "package.json"
+      - ".github/workflows/ci-question-service.yml"
+  push:
+    branches: [dev, staging]
+    paths:
+      - "backend/question-service/**"
+      - "pnpm-lock.yaml"
+      - "package.json"
+      - ".github/workflows/ci-question-service.yml"
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: Build & Smoke tests
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    services:
+      mongodb:
+        image: mongo:8
+        ports:
+          - 27017:27017
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+
+      - name: Enable Corepack & pin pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.17.1 --activate
+          pnpm -v
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend/question-service
+          file: ./backend/question-service/Dockerfile.question
+          push: false
+          tags: question-service:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/backend/question-service/.dockerignore
+++ b/backend/question-service/.dockerignore
@@ -1,0 +1,34 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/.next
+**/.cache
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/charts
+**/docker-compose*
+**/compose.y*ml
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+**/build
+**/dist
+LICENSE
+README.md

--- a/backend/question-service/Dockerfile.question
+++ b/backend/question-service/Dockerfile.question
@@ -1,0 +1,34 @@
+# Use Node.js 20 Alpine as base image
+FROM node:20-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Install pnpm globally
+RUN npm install -g pnpm@10.17.1
+
+# Copy package files
+COPY package.json pnpm-lock.yaml* ./
+
+# Install dependencies
+RUN pnpm install --no-frozen-lockfile
+
+# Copy source code
+COPY . .
+
+# Remove dev dependencies to reduce image size
+RUN pnpm prune --prod
+
+# Create non-root user for security
+RUN addgroup -g 1001 -S nodejs
+RUN adduser -S question-service -u 1001
+
+# Change ownership of the app directory
+RUN chown -R question-service:nodejs /app
+USER question-service
+
+# Expose port the service uses
+EXPOSE 8003
+
+# Start the application
+CMD ["pnpm", "run", "dev"]

--- a/backend/question-service/package.json
+++ b/backend/question-service/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "question-service",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dev": "nodemon src/index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.17.1",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^17.2.3",
+    "express": "^5.1.0",
+    "mongoose": "^8.19.1"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.10"
+  }
+}

--- a/backend/question-service/src/config/db.js
+++ b/backend/question-service/src/config/db.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose')
+
+const connectDB = async () => {
+    try {
+        const con = await mongoose.connect(process.env.MONGODB_URI)
+        console.log(`MongoDB Connected: ${con.connection.host}`)
+    } catch (error) {
+        console.log(error)
+        process.exit(1)
+    }
+}
+
+module.exports = connectDB

--- a/backend/question-service/src/controllers/questionController.js
+++ b/backend/question-service/src/controllers/questionController.js
@@ -9,6 +9,35 @@ const fetchAllQuestions = async (req, res) => {
     res.status(200).json(questions)
 }
 
+const getQuestionById = async (req, res) => {
+    try {
+        const id = req.params.id
+        const mongoose = require('mongoose')
+        if (!mongoose.Types.ObjectId.isValid(id)) {
+            return res.status(400).json({ error: 'Invalid question id' })
+        }
+
+        const q = await Question.findById(id)
+        if (!q) return res.status(404).json({ error: 'Question not found' })
+
+        const resp = {
+            _id: q._id,
+            title: q.title,
+            description: q.description,
+            difficulty: q.difficulty,
+            topic: q.topic,
+            examples: q.examples || [],
+            templates: q.templates || [],
+            link: q.link || null,
+        }
+
+        return res.status(200).json(resp)
+    } catch (err) {
+        console.error('getQuestionById error', err)
+        return res.status(500).json({ error: 'Internal server error' })
+    }
+}
+
 /**
  * GET /v1/questions/pick?topic=&difficulty=
  * Selection rules:
@@ -65,6 +94,7 @@ const pickQuestion = async (req, res) => {
 module.exports = {
     fetchAllQuestions,
     pickQuestion,
+    getQuestionById,
     seedQuestions: async (req, res) => {
         try {
             await Question.deleteMany({})

--- a/backend/question-service/src/controllers/questionController.js
+++ b/backend/question-service/src/controllers/questionController.js
@@ -1,0 +1,78 @@
+const Question = require('../models/questionModel')
+const seedData = require('../data/seed.json')
+
+const DIFFICULTIES = ['Easy', 'Medium', 'Hard']
+const TOPICS = ['String', 'Algorithms', 'Data Structures', 'Databases', 'Bit Manipulation', 'Recursion', 'Arrays', 'Brainteaser']
+
+const fetchAllQuestions = async (req, res) => {
+    const questions = await Question.find({})
+    res.status(200).json(questions)
+}
+
+/**
+ * GET /v1/questions/pick?topic=&difficulty=
+ * Selection rules:
+ * - both provided: match both
+ * - only topic: match topic (difficulty random)
+ * - only difficulty: match difficulty (topic random)
+ * - neither: any random question
+ */
+const pickQuestion = async (req, res) => {
+    try {
+        const topic = req.query.topic
+        const difficulty = req.query.difficulty
+
+        // Validate fields if provided
+        if (topic && !TOPICS.includes(topic)) {
+            return res.status(400).json({ error: 'Invalid topic/difficulty' })
+        }
+        if (difficulty && !DIFFICULTIES.includes(difficulty)) {
+            return res.status(400).json({ error: 'Invalid topic/difficulty' })
+        }
+
+        const pipeline = []
+        const match = {}
+        if (topic) match.topic = topic
+        if (difficulty) match.difficulty = difficulty
+        if (Object.keys(match).length > 0) pipeline.push({ $match: match })
+        pipeline.push({ $sample: { size: 1 } })
+
+        const docs = await Question.aggregate(pipeline)
+        if (!docs || docs.length === 0) {
+            return res.status(404).json({ error: 'No question found for the given criteria' })
+        }
+
+        const q = docs[0]
+        // ensure the response is safe to expose
+        const resp = {
+            _id: q._id,
+            title: q.title,
+            description: q.description,
+            difficulty: q.difficulty,
+            topic: q.topic,
+            examples: q.examples || [],
+            templates: q.templates || [],
+            link: q.link || null,
+        }
+
+        return res.status(200).json(resp)
+    } catch (error) {
+        console.error('pickQuestion error', error)
+        return res.status(500).json({ error: 'Internal server error' })
+    }
+}
+
+module.exports = {
+    fetchAllQuestions,
+    pickQuestion,
+    seedQuestions: async (req, res) => {
+        try {
+            await Question.deleteMany({})
+            const created = await Question.insertMany(seedData)
+            return res.status(200).json({ inserted: created.length })
+        } catch (err) {
+            console.error('seedQuestions error', err)
+            return res.status(500).json({ error: 'Seeding failed' })
+        }
+    },
+}   

--- a/backend/question-service/src/data/seed.json
+++ b/backend/question-service/src/data/seed.json
@@ -1,0 +1,73 @@
+[
+  {
+    "title": "Two Sum",
+    "difficulty": "Easy",
+    "topic": "Arrays",
+    "description": "Given an array of integers nums and an integer target, return indices of the two numbers such that they add up to target. You may assume that each input has exactly one solution.",
+    "examples": [
+      { "input": "nums = [2,7,11,15], target = 9", "output": "[0,1]", "explanation": "nums[0] + nums[1] == 9" }
+    ],
+    "templates": [
+      { "language": "JAVASCRIPT", "starterCode": "var twoSum = function(nums, target) { }" },
+      { "language": "PYTHON", "starterCode": "def two_sum(nums: List[int], target: int) -> List[int]: pass" }
+    ],
+    "link": "https://leetcode.com/problems/two-sum/"
+  },
+  {
+    "title": "Reverse Linked List",
+    "difficulty": "Easy",
+    "topic": "Data Structures",
+    "description": "Reverse a singly linked list and return the reversed list.",
+    "examples": [
+      { "input": "head = [1,2,3,4,5]", "output": "[5,4,3,2,1]" }
+    ],
+    "templates": [
+      { "language": "JAVASCRIPT", "starterCode": "var reverseList = function(head) { }" },
+      { "language": "PYTHON", "starterCode": "def reverseList(head: Optional[ListNode]) -> Optional[ListNode]: pass" }
+    ],
+    "link": "https://leetcode.com/problems/reverse-linked-list/"
+  },
+  {
+    "title": "Binary Tree Level Order Traversal",
+    "difficulty": "Medium",
+    "topic": "Data Structures",
+    "description": "Given the root of a binary tree, return the level order traversal of its nodes' values (from left to right, level by level).",
+    "examples": [
+      { "input": "root = [3,9,20,null,null,15,7]", "output": "[[3],[9,20],[15,7]]" }
+    ],
+    "templates": [
+      { "language": "JAVASCRIPT", "starterCode": "var levelOrder = function(root) { }" },
+      { "language": "PYTHON", "starterCode": "def levelOrder(root: Optional[TreeNode]) -> List[List[int]]: pass" }
+    ],
+    "link": "https://leetcode.com/problems/binary-tree-level-order-traversal/"
+  },
+  {
+    "title": "Longest Increasing Subsequence",
+    "difficulty": "Medium",
+    "topic": "Algorithms",
+    "description": "Given an integer array nums, return the length of the longest strictly increasing subsequence.",
+    "examples": [
+      { "input": "nums = [10,9,2,5,3,7,101,18]", "output": "4", "explanation": "The LIS is [2,3,7,101]" }
+    ],
+    "templates": [
+      { "language": "JAVA", "starterCode": "class Solution { public int lengthOfLIS(int[] nums) { return 0; } }" },
+      { "language": "PYTHON", "starterCode": "def lengthOfLIS(nums: List[int]) -> int: pass" }
+    ],
+    "link": "https://leetcode.com/problems/longest-increasing-subsequence/"
+  },
+  {
+    "title": "Valid Parentheses",
+    "difficulty": "Easy",
+    "topic": "String",
+    "description": "Given a string s containing just the characters '(', ')', '{', '}', '[' and ']', determine if the input string is valid.",
+    "examples": [
+      { "input": "s = '()[]{}'", "output": "true" },
+      { "input": "s = '(]'", "output": "false" }
+    ],
+    "templates": [
+      { "language": "JAVASCRIPT", "starterCode": "var isValid = function(s) { }" },
+      { "language": "PYTHON", "starterCode": "def isValid(s: str) -> bool: pass" }
+    ],
+    "link": "https://leetcode.com/problems/valid-parentheses/"
+  }
+]

--- a/backend/question-service/src/index.js
+++ b/backend/question-service/src/index.js
@@ -1,0 +1,32 @@
+const express = require('express')
+const cors = require('cors')
+const dotenv = require('dotenv').config()
+const connectDB = require('./config/db')
+
+connectDB()
+
+const app = express()
+
+app.use(cors({
+  origin: 'http://localhost:3000',
+  credentials: true,
+  optionsSuccessStatus: 200,
+}));
+
+app.use(express.json())
+app.use(express.urlencoded({ extended: false }))
+
+const PORT = process.env.PORT || 8080
+
+app.listen(PORT, () => {
+  console.log(`Question service is running on port ${PORT}...`)
+})
+
+app.get('/', (req, res) => {
+  res.json({ message: 'Question service is up and running!' })
+})
+
+// Mount v1 routes for the question service
+app.use('/v1/questions', require('./routes/questionRoutes'))
+
+module.exports = app

--- a/backend/question-service/src/models/questionModel.js
+++ b/backend/question-service/src/models/questionModel.js
@@ -1,0 +1,57 @@
+const mongoose = require('mongoose')
+
+const questionSchema = mongoose.Schema({
+    title: {
+        type: String,
+        required: true
+    },
+    difficulty: {
+        type: String,
+        enum: ['Easy', 'Medium', 'Hard'],
+        required: true
+    },
+    topic: {
+        type: String,
+        enum: ['String', 'Algorithms', 'Data Structures', 'Databases', 
+            'Bit Manipulation', 'Recursion', 'Arrays', 'Brainteaser'],
+        required: true
+    },
+    description: {
+        type: String,
+        required: true
+    },
+    examples: {
+    type: [
+        {
+        input: {
+          type: String,
+          required: true,
+          },
+        output: {
+          type: String,
+          required: true,
+          },
+        explanation: {
+          type: String,
+          },
+        },
+      ],
+    },
+    templates: {
+    type: [
+      {
+        language: {
+          type: String,
+          required: true,
+        },
+        starterCode: {
+          type: String,
+          required: true,
+        },
+      },
+    ],
+  },
+})
+
+// Export to be used in the controller
+module.exports = mongoose.model('Question', questionSchema)

--- a/backend/question-service/src/routes/questionRoutes.js
+++ b/backend/question-service/src/routes/questionRoutes.js
@@ -1,9 +1,10 @@
 const express = require('express')
 const router = express.Router()
-const { fetchAllQuestions, pickQuestion, seedQuestions } = require('../controllers/questionController')
+const { fetchAllQuestions, pickQuestion, seedQuestions, getQuestionById } = require('../controllers/questionController')
 
 router.route('/').get(fetchAllQuestions)
 router.route('/pick').get(pickQuestion)
 router.route('/seed').post(seedQuestions)
+router.route('/:id').get(getQuestionById)
 
 module.exports = router

--- a/backend/question-service/src/routes/questionRoutes.js
+++ b/backend/question-service/src/routes/questionRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express')
+const router = express.Router()
+const { fetchAllQuestions, pickQuestion, seedQuestions } = require('../controllers/questionController')
+
+router.route('/').get(fetchAllQuestions)
+router.route('/pick').get(pickQuestion)
+router.route('/seed').post(seedQuestions)
+
+module.exports = router

--- a/backend/question-service/src/seed-runner.js
+++ b/backend/question-service/src/seed-runner.js
@@ -1,0 +1,41 @@
+const fs = require('fs')
+const path = require('path')
+const mongoose = require('mongoose')
+const Question = require('./models/questionModel')
+
+const seedFile = path.join(__dirname, 'data', 'seed.json')
+
+const MONGODB_URI = process.env.MONGODB_URI || process.env.DB_URI || 'mongodb://admin:password@localhost:27017/question-service?authSource=admin'
+
+async function run() {
+  if (!fs.existsSync(seedFile)) {
+    console.error('Seed file not found:', seedFile)
+    process.exit(1)
+  }
+
+  const data = JSON.parse(fs.readFileSync(seedFile, 'utf8'))
+
+  try {
+    console.log('Connecting to', MONGODB_URI)
+    await mongoose.connect(MONGODB_URI, { useNewUrlParser: true, useUnifiedTopology: true })
+
+    console.log('Clearing questions collection...')
+    await Question.deleteMany({})
+
+    console.log('Inserting seed documents...')
+    const created = await Question.insertMany(data)
+    console.log(`Inserted ${created.length} documents.`)
+
+    await mongoose.disconnect()
+    console.log('Done')
+    process.exit(0)
+  } catch (err) {
+    console.error('Seeding failed', err)
+    try { await mongoose.disconnect() } catch (_) {}
+    process.exit(1)
+  }
+}
+
+if (require.main === module) run()
+
+module.exports = run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,22 @@ services:
     networks:
       - cs3219-peerprep-network
 
+  question-service:
+    build:
+      context: ./backend/question-service
+      dockerfile: Dockerfile
+    container_name: question-service
+    restart: always
+    ports:
+      - '8003:8003'
+    environment:
+      - MONGODB_URI=mongodb://admin:password@mongodb:27017/peerprep?authSource=admin
+      - PORT=8003
+    depends_on:
+      - mongodb
+    networks:
+      - cs3219-peerprep-network
+
 networks:
   cs3219-peerprep-network:
     driver: bridge

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,25 @@ importers:
         specifier: ^8.44.1
         version: 8.46.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
 
+  backend/question-service:
+    dependencies:
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.5
+      dotenv:
+        specifier: ^17.2.3
+        version: 17.2.3
+      express:
+        specifier: ^5.1.0
+        version: 5.1.0
+      mongoose:
+        specifier: ^8.19.1
+        version: 8.19.1
+    devDependencies:
+      nodemon:
+        specifier: ^3.1.10
+        version: 3.1.10
+
   frontend:
     dependencies:
       '@emotion/react':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,25 @@ importers:
         specifier: ^3.1.10
         version: 3.1.10
 
+  backend/question-service:
+    dependencies:
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.5
+      dotenv:
+        specifier: ^17.2.3
+        version: 17.2.3
+      express:
+        specifier: ^5.1.0
+        version: 5.1.0
+      mongoose:
+        specifier: ^8.19.1
+        version: 8.19.1
+    devDependencies:
+      nodemon:
+        specifier: ^3.1.10
+        version: 3.1.10
+
   frontend:
     dependencies:
       '@emotion/react':


### PR DESCRIPTION
# Question Service Implementation

This PR introduces or updates the Question microservice: an Express + Mongoose backend that stores technical interview questions and exposes endpoints to seed and fetch questions by topic and difficulty.

## Summary

- What changed: (briefly list the files / features touched, e.g. new endpoints, model changes, seed data)
- Why: (motivation / context for the change)
- Related issue: Fixes # (issue number) — if applicable

## Data Schema

### Question Model

```typescript
{
	_id: ObjectId,
	title: string,
	difficulty: 'Easy' | 'Medium' | 'Hard',
	topic: string,
	description: string,
	examples: { input: string; output: string; explanation?: string }[],
	templates: { language: string; starterCode: string }[],
	link?: string,
	createdAt?: Date,
	updatedAt?: Date
}
```

## API Endpoints (implemented in this PR)

| Method | Endpoint                                | Description                            |
| ------ | --------------------------------------- | -------------------------------------- |
| GET    | `/v1/questions`                         | List all questions                     |
| GET    | `/v1/questions/pick?topic=&difficulty=` | Return exactly one matching question   |
| POST   | `/v1/questions/seed`                    | Replace questions collection with seed |

### Selection behavior for `/v1/questions/pick`

- Both `topic` and `difficulty` present: return one random question matching both.
- Only `topic` present: return one random question matching the topic.
- Only `difficulty` present: return one random question matching the difficulty.
- No params: return one random question.
- Matching is case-insensitive and implemented with aggregation + `$sample`.

## How to run locally / seed

1. From repo root:

```powershell
cd backend/question-service
pnpm install
```

2. Seed the DB (docker-compose Mongo uses `admin:password` by default):

```powershell
# $env:MONGODB_URI = 'mongodb://admin:password@localhost:27017/question-service?authSource=admin'
node src/seed-runner.js
```

3. Start service:

```powershell
# $env:MONGODB_URI = 'mongodb://admin:password@localhost:27017/question-service?authSource=admin'
pnpm run dev
```

## Notes

- Seed data is located at `backend/question-service/src/data/seed.json` (5 sample questions).
- Default server port is `8003` (defined in `.env` and used by `src/index.js`).
- The seeder clears the `questions` collection before inserting the seed.
- If running via Docker Compose, `MONGODB_URI` in compose should point to `mongodb` service (e.g. `mongodb://admin:password@mongodb:27017/peerprep?authSource=admin`).

## Tests / Validation done

- Manual: seeded DB and exercised `GET /v1/questions` and `GET /v1/questions/pick` for several cases.
- Linting/formatting: (state whether `pnpm lint` / `pnpm format` were run or skipped)

## Checklist

- [ ] I have run `pnpm lint` and `pnpm format`
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Follow-ups

- Add authentication/authorization for write endpoints (seed/admin) for the user service
